### PR TITLE
jenkins-on-kubernetes to 0.0.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.89
 - name: jenkins-on-kubernetes
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.5
+  version: 0.0.6


### PR DESCRIPTION
Promote jenkins-on-kubernetes to version 0.0.6